### PR TITLE
added option to ignore dlc updates

### DIFF
--- a/console.go
+++ b/console.go
@@ -136,7 +136,7 @@ func (c *Console) Start() {
 
 	if settingsObj.CheckForMissingUpdates {
 		fmt.Printf("\nChecking for missing updates\n")
-		c.processMissingUpdates(localDB, titlesDB)
+		c.processMissingUpdates(localDB, titlesDB, settingsObj)
 	}
 
 	if settingsObj.CheckForMissingDLC {
@@ -166,8 +166,8 @@ func (c *Console) processIssues(localDB *db.LocalSwitchFilesDB) {
 	t.Render()
 }
 
-func (c *Console) processMissingUpdates(localDB *db.LocalSwitchFilesDB, titlesDB *db.SwitchTitlesDB) {
-	incompleteTitles := process.ScanForMissingUpdates(localDB.TitlesMap, titlesDB.TitlesMap)
+func (c *Console) processMissingUpdates(localDB *db.LocalSwitchFilesDB, titlesDB *db.SwitchTitlesDB, settingsObj *settings.AppSettings) {
+	incompleteTitles := process.ScanForMissingUpdates(localDB.TitlesMap, titlesDB.TitlesMap, settingsObj.IgnoreDLCUpdates)
 	if len(incompleteTitles) != 0 {
 		fmt.Print("\nFound available updates:\n\n")
 	} else {

--- a/gui.go
+++ b/gui.go
@@ -358,7 +358,8 @@ func (g *GUI) getMissingDLC() string {
 }
 
 func (g *GUI) getMissingUpdates() string {
-	missingUpdates := process.ScanForMissingUpdates(g.state.localDB.TitlesMap, g.state.switchDB.TitlesMap)
+	settingsObj := settings.ReadSettings(g.baseFolder)
+	missingUpdates := process.ScanForMissingUpdates(g.state.localDB.TitlesMap, g.state.switchDB.TitlesMap, settingsObj.IgnoreDLCUpdates)
 	values := make([]process.IncompleteTitle, len(missingUpdates))
 	i := 0
 	for _, missingUpdate := range missingUpdates {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -60,6 +60,7 @@ type AppSettings struct {
 	OrganizeOptions        OrganizeOptions `json:"organize_options"`
 	ScanRecursively        bool            `json:"scan_recursively"`
 	GuiPagingSize          int             `json:"gui_page_size"`
+	IgnoreDLCUpdates       bool            `json:"ignore_dlc_updates"`
 	IgnoreDLCTitleIds      []string        `json:"ignore_dlc_title_ids"`
 }
 
@@ -99,6 +100,7 @@ func saveDefaultSettings(baseFolder string) *AppSettings {
 		Folder:                 "",
 		ScanFolders:            []string{},
 		IgnoreDLCTitleIds:      []string{},
+		IgnoreDLCUpdates:       false,
 		GUI:                    true,
 		GuiPagingSize:          100,
 		CheckForMissingUpdates: true,


### PR DESCRIPTION
added "ignore_dlc_updates" to settings.json as a boolean to enable ignoring dlc updates in the missing updates tab