### PR TITLE
Add new settings.json functionality to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note: Only the header_key, and the key_area_key_application_XX keys are required
 
 During the App first launch a "settings.json" file will be created, that allows for granular control over the Apps execution.
 
-You can customize the folder/file re-naming, as well as turn on/off features.
+You can customize the folder/file re-naming, as well as turn on/off features, and set specific title ids of DLC or updates to ignore.
 
 ```json
 {
@@ -64,6 +64,9 @@ You can customize the folder/file re-naming, as well as turn on/off features.
  },
  "scan_recursively": true,
  "gui_page_size": 100
+ "ignore_dlc_updates": false,
+ "ignore_dlc_title_ids: [] # Enter as a list of string, e.g. ["1234567890ABCDEF". "1234567890ABCDEE", "1234567890ABCDFF"]
+ "ignore_update_title_ids": [] # Enter as a list of string, e.g. ["1234567890ABCDEF". "1234567890ABCDEE", "1234567890ABCDFF"]
 }
 ```
 


### PR DESCRIPTION
In the latest release I saw that there was the functionality to added to ignore specific updates, but it wasn't documented. And in the process I saw there was the ability to ignore DLC as well. It took me a few minutes to figure out exactly how it worked looking for documentation and figure this will help others if it's specified in the README.